### PR TITLE
arch-to-nvchecker: Add typing support, unify quoting and remove nested ifs

### DIFF
--- a/arch-to-nvchecker
+++ b/arch-to-nvchecker
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 
-import pyalpm
 import argparse
+from dataclasses import dataclass
+
+import pyalpm
 from nvchecker import core as nvchecker_core
 from nvchecker.util import RichResult
 
@@ -12,9 +14,16 @@ PREFIX_MAP = {
     "gems": "ruby-",
     "npm": "nodejs-",
 }
+@dataclass
+class ParserArgs:
+    """Define argument types to support argument type hints"""
+
+    update: bool
+    db: list[str]
+    newer: bool
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description='Check or update nvchecker oldver db from pacman sync db')
     parser.add_argument('-u', '--update', action="store_true",
                         help='Actually update nvchecker db after printing the difference')
@@ -23,7 +32,7 @@ def main():
                         help='Pacman sync db to consider. Defaulting to all with testing and multilib enabled')
     parser.add_argument("-n", "--newer", action="store_true",
                         help='Only consider entry when pacman version is not newer than newver (useful when Arch bumped to an alpha, etc)')
-    args = parser.parse_args()
+    args = ParserArgs(**vars(parser.parse_args()))
 
     nvchecker_config = nvchecker_core.get_default_config()
     nvchecker_entries, nvchecker_options = nvchecker_core.load_file(nvchecker_config, use_keymanager=False)

--- a/arch-to-nvchecker
+++ b/arch-to-nvchecker
@@ -8,11 +8,11 @@ from nvchecker import core as nvchecker_core
 from nvchecker.util import RichResult
 
 PREFIX_MAP = {
-    "pypi": "python-",
-    "cpan": "perl-",
-    "hackage": "haskell-",
-    "gems": "ruby-",
-    "npm": "nodejs-",
+    'pypi': 'python-',
+    'cpan': 'perl-',
+    'hackage': 'haskell-',
+    'gems': 'ruby-',
+    'npm': 'nodejs-',
 }
 @dataclass
 class ParserArgs:
@@ -25,32 +25,33 @@ class ParserArgs:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description='Check or update nvchecker oldver db from pacman sync db')
-    parser.add_argument('-u', '--update', action="store_true",
+    parser.add_argument('-u', '--update', action='store_true',
                         help='Actually update nvchecker db after printing the difference')
-    parser.add_argument('--db', nargs="*", default=["core-testing", "core", "extra-testing", "extra",
-                                                    "multilib-testing", "multilib"],
+    parser.add_argument('--db', nargs='*', default=['core-testing', 'core', 'extra-testing', 'extra',
+                                                    'multilib-testing', 'multilib'],
                         help='Pacman sync db to consider. Defaulting to all with testing and multilib enabled')
-    parser.add_argument("-n", "--newer", action="store_true",
+    parser.add_argument('-n', '--newer', action='store_true',
                         help='Only consider entry when pacman version is not newer than newver (useful when Arch bumped to an alpha, etc)')
     args = ParserArgs(**vars(parser.parse_args()))
 
     nvchecker_config = nvchecker_core.get_default_config()
     nvchecker_entries, nvchecker_options = nvchecker_core.load_file(nvchecker_config, use_keymanager=False)
 
+    # TODO(C0rn3j): nvchecker_options.ver_files can be None
     oldvers = nvchecker_core.read_verfile(nvchecker_options.ver_files[0])
     newvers = nvchecker_core.read_verfile(nvchecker_options.ver_files[1])
 
-    handle = pyalpm.Handle(".", "/var/lib/pacman")
+    handle = pyalpm.Handle('.', '/var/lib/pacman')
 
     archvers = {}
     for db in args.db:
         db_handle = handle.register_syncdb(db, 0)
-        for package in db_handle.search(""):
+        for package in db_handle.search(''):
             if package.name in archvers:
                 continue
-            archvers[package.name] = package.version.split("-")[0]
-            if ":" in archvers[package.name]:
-                archvers[package.name] = archvers[package.name].split(":")[1]
+            archvers[package.name] = package.version.split('-')[0]
+            if ':' in archvers[package.name]:
+                archvers[package.name] = archvers[package.name].split(':')[1]
 
     for entry_name in newvers:
         pkgname = entry_name
@@ -61,19 +62,19 @@ def main() -> None:
 
         entry = nvchecker_entries[pkgname]
 
-        if entry.get("arch_ignored"):
+        if entry.get('arch_ignored'):
             continue
 
-        if _pkgname := entry.get("arch_pkgname"):
+        if _pkgname := entry.get('arch_pkgname'):
             pkgname = _pkgname
         else:
-            pkgname = PREFIX_MAP.get(entry["source"], "") + pkgname.lower()
+            pkgname = PREFIX_MAP.get(entry['source'], '') + pkgname.lower()
 
-            if pkgname not in archvers and "_" in pkgname:
-                pkgname = pkgname.replace("_", "-")
+            if pkgname not in archvers and '_' in pkgname:
+                pkgname = pkgname.replace('_', '-')
 
-            if pkgname not in archvers and "." in pkgname:
-                pkgname = pkgname.replace(".", "-")
+            if pkgname not in archvers and '.' in pkgname:
+                pkgname = pkgname.replace('.', '-')
 
             if pkgname not in archvers and pkgname != entry_name:
                 pkgname = entry_name
@@ -88,15 +89,13 @@ def main() -> None:
         if oldver is not None:
             oldver = oldver.version
         if archver != oldver:
-            if oldver is not None:
-                if oldver + ".0" == archver or archver + ".0" == oldver:
-                    continue
+            if oldver is not None and (oldver + '.0' == archver or archver + '.0' == oldver):
+                continue
 
-            if args.newer:
-                if pyalpm.vercmp(archver, newvers[entry_name]) > 0:
-                    continue
+            if args.newer and pyalpm.vercmp(archver, newvers[entry_name]) > 0:
+                continue
 
-            print(pkgname, oldver, "->", archver)
+            print(pkgname, oldver, '->', archver)
             oldvers[entry_name] = RichResult(version=archver)
 
     if args.update:


### PR DESCRIPTION
Typing support was added to args.

There is an uncaught None error that is now commented as at least a TODO, as I was not 100% certain how it should be handled.

Quotes were all over the place, unified to single quotes:  
![image](https://github.com/user-attachments/assets/ced6f56e-e959-4cdc-86d7-2030a10f75bd)
